### PR TITLE
Update manifest.jps

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -29,8 +29,8 @@ onInstall:
 actions:
   deployArchive:
     deploy:
-      archive: https://github.com/elmsln/HAXcms/archive/refs/tags/7.0.1.zip
-      name: HAXcms-7.0.1
+      archive: https://github.com/elmsln/HAXcms/archive/refs/tags/7.0.2.zip
+      name: HAXcms-7.0.2
       context: ROOT
 
   configSystem:


### PR DESCRIPTION
fix to support https on reclaim hosting environment

I won't be able to know if it works on reclaimhosting until it's deployed and try but your systems had a slightly different way for PHP to detect that it was a valid HTTPS connection so I had to add some support in to realize this and then still enable https in my app. Without it, all uploads fail (and some page operations) bc they are sent over http and don't automatically redirect to https