### PR TITLE
Update release URLs for HAXcms in manifest.jps

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -31,7 +31,7 @@ actions:
     cmd[cp]: |-
       # Find version number of latest release
       function get_latest_release {
-        curl --silent "https://api.github.com/repos/elmsln/HAXcms/releases/latest" |
+        curl --silent "https://api.github.com/repos/haxtheweb/haxcms-php/releases/latest" |
         grep '"tag_name":' |
         sed -E 's/.*"([^"]+)".*/\1/' |
         sed 's/v//'
@@ -39,7 +39,7 @@ actions:
       LATEST=`get_latest_release`
       # Download and unzip archive
       cd /var/www/webroot/ROOT
-      wget https://github.com/elmsln/HAXcms/archive/refs/tags/$LATEST.zip
+      wget https://github.com/haxtheweb/haxcms-php/archive/refs/tags/$LATEST.zip
       unzip $LATEST.zip
       cd HAXcms-$LATEST/
       mv * .[^.]* ..


### PR DESCRIPTION
updated to reflect the fact that PHP now lives in its own https://github.com/haxtheweb/haxcms-php repo so that HAX installer works again on reclaim cloud